### PR TITLE
Fix Heroku deployments after incident 2466

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,4 @@
-https://github.com/MercuryTechnologies/heroku-buildpack-nodejs.git#f18e6b9987b9eda41afe723321988679ec148431
+https://github.com/MercuryTechnologies/heroku-buildpack-nodejs.git#920cb15aaaad914e636d6e4951ffa2a63b55bd94
 https://github.com/mars/create-react-app-inner-buildpack.git#cb0c9d2fdefaa50eb294a6a0999d5ab3f0b83271
 https://github.com/heroku/heroku-buildpack-static.git#21c1f5175186b70cf247384fd0bf922504b419be
 https://github.com/ekilah/heroku-buildpack-post-build-clean.git#48a468eb46b5ff6f458f3445ac38f699e19bcf43


### PR DESCRIPTION
[Heroku incident](https://status.heroku.com/incidents/2466)
[Heroku support thread (useless)](https://help.heroku.com/1170322)
[Slack thread](https://mercurytechnologies.slack.com/archives/C028TAJ0W4A/p1667924654423239)

As it turns out, the fix that Heroku deployed to resolve incident 2466 was rolled out _inside their buildpacks_. Specifically, it was hidden in a commit that updates the Go version, and then not announced to anybody (nor mentioned by support). I have already updated our fork of the `nodejs` buildpack with the relevant changes, so all we need to do to have this go live for all envs is bump the pinned commit here.

* [Here are all changes](https://github.com/MercuryTechnologies/heroku-buildpack-nodejs/commit/920cb15aaaad914e636d6e4951ffa2a63b55bd94) included in the merge.
* [Here's the one specific commit](https://github.com/MercuryTechnologies/heroku-buildpack-nodejs/commit/3b91e2f3134c7379ed34fe7d39e8f4dfd0545b0c) and its [PR description](https://github.com/heroku/heroku-buildpack-nodejs/pull/1050)